### PR TITLE
add isPlayerFinished

### DIFF
--- a/Arduino15/packages/SPRESENSE/hardware/spresense/1.0.0/libraries/Audio/Audio.h
+++ b/Arduino15/packages/SPRESENSE/hardware/spresense/1.0.0/libraries/Audio/Audio.h
@@ -735,6 +735,17 @@ public:
      return m_es_size;
    }
 
+    bool isPlayerFinished(PlayerId id)
+    {
+      CMN_SimpleFifoHandle *handle =
+        (id == Player0) ?
+        &m_player0_simple_fifo_handle : &m_player1_simple_fifo_handle;
+
+      size_t occupied_size = CMN_SimpleFifoGetOccupiedSize(handle);
+
+      return (occupied_size == 0);
+    }
+
 private:
 
   /**


### PR DESCRIPTION
I tried to add `bool isPlayerFinished(PlayerID)` to get if the player has finished playing fifo buffer data, because I wanted to detect if the Player0/1 has finished playing (to repeat sounds). I also tried:

- derive from AudioClass -> couldn't handle CMN_SimpleFifoHandle from derived class (private member)
- detect from audio attention callback -> could'nt detect which player has finished playing (FIFO buffer underflow, Attention Code = 1, Attention Sub Code = 5)

If you have better solution for this problem, let me know please.
Thank you.