### PR TITLE
Change math library to use newlib toolchain

### DIFF
--- a/Arduino15/packages/SPRESENSE/hardware/spresense/1.0.0/cores/spresense/Arduino.h
+++ b/Arduino15/packages/SPRESENSE/hardware/spresense/1.0.0/cores/spresense/Arduino.h
@@ -26,6 +26,7 @@
 #include <string.h>
 #include <nuttx/config.h>
 #include <sdk/config.h>
+#include <math.h>
 
 // Some libraries assumes that AVR-specific definitions are
 // automatically included from Arduino.h... Therefore, here
@@ -33,12 +34,6 @@
 
 #include "avr/pgmspace.h"
 #include "avr/interrupt.h"
-
-#ifdef CONFIG_LIBM
-#include <math.h>
-#else
-#error Please enable LIBM in nuttx
-#endif // CONFIG_LIBM
 
 #include "binary.h"
 //#include "itoa.h"

--- a/Arduino15/packages/SPRESENSE/hardware/spresense/1.0.0/platform.txt
+++ b/Arduino15/packages/SPRESENSE/hardware/spresense/1.0.0/platform.txt
@@ -29,7 +29,7 @@ compiler.S.flags=-c {compiler.warning_flags} -MMD -std=gnu99 -c -fno-builtin -ma
 compiler.c.elf.flags=-ggdb -mthumb -mcpu=cortex-m4 -mfloat-abi=hard -mfpu=fpv4-sp-d16 -Xlinker --entry=__start -nodefaultlibs -nostartfiles "{build.stack}" "-T{build.libpath}/build/ramconfig.ld" -Wl,--gc-sections
 
 compiler.c.elf.cmd=arm-none-eabi-g++
-compiler.c.elf.libs= "{build.libpath}/libs/libapps.a" "{build.libpath}/libs/libnuttx.a" -lgcc
+compiler.c.elf.libs= "{build.libpath}/libs/libapps.a" "{build.libpath}/libs/libnuttx.a" -lgcc -lm
 
 compiler.cpp.cmd=arm-none-eabi-g++
 compiler.cpp.flags=-c {compiler.warning_flags} -MMD -std=gnu++98 -c -fno-builtin -mabi=aapcs -Wall -Os -fno-strict-aliasing -fno-strength-reduce -fomit-frame-pointer -mcpu=cortex-m4 -mthumb -mfpu=fpv4-sp-d16 -mfloat-abi=hard -pipe -ffunction-sections -fno-exceptions -fno-rtti -ggdb -gdwarf-3 -ffunction-sections -fdata-sections


### PR DESCRIPTION
NuttX built-in math library is ther lower performance than newlib one.
And the newlib math library has been widely used and is stable. So this
commit and the other update of SDK prebuilt libraries changes math
library from NuttX original to newlib in compiler toolchain.