### PR TITLE
fix unsuitable comment

### DIFF
--- a/Arduino15/packages/SPRESENSE/hardware/spresense/1.0.0/libraries/GNSS/examples/gnss_tracker/gnss_file.cpp
+++ b/Arduino15/packages/SPRESENSE/hardware/spresense/1.0.0/libraries/GNSS/examples/gnss_tracker/gnss_file.cpp
@@ -114,7 +114,7 @@ int ReadChar(char* pBuff, int BufferSize, const char* pName, int flag)
   }
   else
   {
-    /* Write file. */
+    /* Read file. */
     read_result = myFile.read(pBuff, BufferSize);
     if (read_result == 0)
     {


### PR DESCRIPTION
Fix unsuitable comment in gnss_file.cpp of gnss_tracker example.
In ReadChar function, we can find `/* Write file. */` comment.
This should be `/* Read file. */`.
