### PR TITLE
gnss_tracker: Fixed NMEA format string bug

### DIFF
--- a/Arduino15/packages/SPRESENSE/hardware/spresense/1.0.0/libraries/GNSS/examples/gnss_tracker/gnss_nmea.cpp
+++ b/Arduino15/packages/SPRESENSE/hardware/spresense/1.0.0/libraries/GNSS/examples/gnss_tracker/gnss_nmea.cpp
@@ -95,9 +95,9 @@ static void CoordinateToString(char *pBuffer, int length, double Coordinate,
   }
   fixeddig = CordInfo[cordinate_type].fixeddigit;
   Degree = (int) tmp;
-  tmp = (tmp - (double)Degree) * 60;
+  tmp = (tmp - (double)Degree) * 60 + 0.00005;
   Minute = (int)tmp;
-  tmp = (tmp - (double)Minute) * 10000 + 0.5;
+  tmp = (tmp - (double)Minute) * 10000;
   Minute2 = (int)tmp;
 
   snprintf(pBuffer, length, "%0*d%02d.%04d,%c,", fixeddig, Degree, Minute, Minute2, direction);


### PR DESCRIPTION
Fixed NMEA format string bug
Fixed incorrect calculation for rounding.
In some cases, the number after the decimal point was 10000.

For example, "35.5333325N" is converted to "3531.10000,N,".
The correct answer is "3532.0000,N,".

四捨五入の計算にバグがあったので修正しました。
例えば、 35.5333325N だった場合、 3531.10000,N, になってました。
正しくは、 3532.0000,N, です。