### PR TITLE
fix type to SpSatellite.azimuth

### DIFF
--- a/Arduino15/packages/SPRESENSE/hardware/spresense/1.0.0/libraries/GNSS/GNSS.h
+++ b/Arduino15/packages/SPRESENSE/hardware/spresense/1.0.0/libraries/GNSS/GNSS.h
@@ -134,7 +134,7 @@ public:
                                  w/ positioning augmentation of SBAS or QZSS L1S */
   unsigned char  svid;      /**< Satellite ID */
   unsigned char  elevation; /**< Elevation of satellite [degree] */
-  unsigned char  azimuth;   /**< Azimuth of satellite [degree]; Clockwise from the north */
+  unsigned short azimuth;   /**< Azimuth of satellite [degree]; Clockwise from the north */
   float sigLevel;           /**< C/N [dBHz] */
 };
 


### PR DESCRIPTION
The value may change.
**cxd56_gnss_sv_s.azimuth** is defined as int16_t.
**SpSatellite.azimuth** is a less accurate type than int16_t.
azimuth has 0 to 359.

**cxd56_gnss_sv_s.azimuth** は _int16_t_ であるが、_unsigned char_ 型の **SpSatellite.azimuth** に代入しています。
azimuthが取りうる値は0~359です。